### PR TITLE
feat: add dashboard timeframe switch and persistence

### DIFF
--- a/src/pages/dashboard/Dashboard.jsx
+++ b/src/pages/dashboard/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import {
   Alert,
   Badge,
@@ -23,13 +23,33 @@ import {
   Eye,
   Person,
   Telephone,
+  ArrowUp,
+  ArrowDown,
+  People,
+  Cart,
+  CurrencyDollar,
+  Activity,
 } from 'react-bootstrap-icons';
 import { Link } from 'react-router-dom';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
 
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { fetchPosts } from '../../features/posts/postsSlice';
 import Widget from '../../components/Widget';
+import { getDashboardData, timeframeOptions } from './mock';
 import s from './Dashboard.module.scss';
+
+const STORAGE_KEY = 'dashboard_timeframe';
+const DEFAULT_TIMEFRAME = '7d';
 
 const formatDate = (value) =>
   new Intl.DateTimeFormat('en', {
@@ -37,6 +57,25 @@ const formatDate = (value) =>
     day: 'numeric',
     year: 'numeric',
   }).format(new Date(value));
+
+const formatNumber = (num) => {
+  if (num >= 10000) {
+    return (num / 10000).toFixed(1) + '万';
+  }
+  return num.toLocaleString();
+};
+
+const getStoredTimeframe = () => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored && timeframeOptions.some(opt => opt.value === stored)) {
+      return stored;
+    }
+  } catch (e) {
+    console.warn('Failed to read timeframe from localStorage:', e);
+  }
+  return DEFAULT_TIMEFRAME;
+};
 
 const quickLinks = [
   {
@@ -69,11 +108,121 @@ const quickLinks = [
   },
 ];
 
+const TimeframeSelector = ({ value, onChange }) => (
+  <ButtonGroup className={s.timeframeGroup}>
+    {timeframeOptions.map((option) => (
+      <Button
+        key={option.value}
+        color={value === option.value ? 'primary' : 'secondary'}
+        outline={value !== option.value}
+        onClick={() => onChange(option.value)}
+        className={s.timeframeButton}
+      >
+        {option.label}
+      </Button>
+    ))}
+  </ButtonGroup>
+);
+
+const StatCard = ({ icon: Icon, title, value, growth, color }) => {
+  const isPositive = growth >= 0;
+  return (
+    <Widget className={s.statCard}>
+      <div className={s.statCardInner}>
+        <div className={s.statCardIcon} style={{ backgroundColor: `${color}15`, color }}>
+          <Icon size={24} />
+        </div>
+        <div className={s.statCardContent}>
+          <div className={s.statCardTitle}>{title}</div>
+          <div className={s.statCardValue}>{formatNumber(value)}</div>
+          <div className={`${s.statCardGrowth} ${isPositive ? s.statCardGrowthPositive : s.statCardGrowthNegative}`}>
+            {isPositive ? <ArrowUp size={14} /> : <ArrowDown size={14} />}
+            <span>{Math.abs(growth)}%</span>
+            <span className={s.statCardGrowthLabel}>vs 上期</span>
+          </div>
+        </div>
+      </div>
+    </Widget>
+  );
+};
+
+const EmptyState = ({ title, message, icon: Icon }) => (
+  <div className={s.emptyState}>
+    <div className={s.emptyStateIcon}>
+      {Icon ? <Icon size={48} /> : null}
+    </div>
+    <h5 className={s.emptyStateTitle}>{title}</h5>
+    <p className={s.emptyStateMessage}>{message}</p>
+  </div>
+);
+
+const MainChart = ({ data, hasData }) => {
+  if (!hasData || data.length === 0) {
+    return (
+      <EmptyState
+        title="暂无数据"
+        message="该时间段内没有可用的统计数据，请尝试切换其他时间段"
+        icon={Activity}
+      />
+    );
+  }
+
+  return (
+    <ResponsiveContainer height={350} width="100%">
+      <LineChart data={data} margin={{ top: 20, right: 30, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e9ecef" />
+        <XAxis
+          dataKey="name"
+          stroke="#6c757d"
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          stroke="#6c757d"
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={(value) => `${value >= 1000 ? (value / 1000).toFixed(0) + 'k' : value}`}
+        />
+        <Tooltip
+          contentStyle={{
+            backgroundColor: '#fff',
+            border: '1px solid #e9ecef',
+            borderRadius: '0.375rem',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+          }}
+        />
+        <Legend />
+        <Line
+          type="monotone"
+          dataKey="pv"
+          stroke="#3754a5"
+          strokeWidth={2}
+          dot={{ r: 4, fill: '#3754a5' }}
+          activeDot={{ r: 6 }}
+          name="页面访问"
+        />
+        <Line
+          type="monotone"
+          dataKey="uv"
+          stroke="#eb3349"
+          strokeWidth={2}
+          dot={{ r: 4, fill: '#eb3349' }}
+          activeDot={{ r: 6 }}
+          name="独立访客"
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+};
+
 const Dashboard = () => {
   const dispatch = useAppDispatch();
   const posts = useAppSelector((state) => state.posts.items);
   const fetchStatus = useAppSelector((state) => state.posts.fetchStatus);
   const [isDropdownOpened, setIsDropdownOpened] = useState(false);
+  const [timeframe, setTimeframe] = useState(getStoredTimeframe);
 
   useEffect(() => {
     if (fetchStatus === 'idle' && posts.length === 0) {
@@ -81,7 +230,54 @@ const Dashboard = () => {
     }
   }, [dispatch, fetchStatus, posts.length]);
 
+  const handleTimeframeChange = useCallback((newTimeframe) => {
+    setTimeframe(newTimeframe);
+    try {
+      localStorage.setItem(STORAGE_KEY, newTimeframe);
+    } catch (e) {
+      console.warn('Failed to save timeframe to localStorage:', e);
+    }
+  }, []);
+
+  const dashboardData = useMemo(
+    () => getDashboardData(timeframe),
+    [timeframe]
+  );
+
+  const { stats, chartData, hasData } = dashboardData;
+
   const recentPosts = useMemo(() => posts.slice(0, 5), [posts]);
+
+  const statCards = [
+    {
+      icon: People,
+      title: '总用户数',
+      value: stats.totalUsers,
+      growth: stats.userGrowth,
+      color: '#3754a5',
+    },
+    {
+      icon: Activity,
+      title: '活跃用户',
+      value: stats.activeUsers,
+      growth: stats.userGrowth,
+      color: '#1ab394',
+    },
+    {
+      icon: Cart,
+      title: '新订单',
+      value: stats.newOrders,
+      growth: stats.orderGrowth,
+      color: '#f3c363',
+    },
+    {
+      icon: CurrencyDollar,
+      title: '总收入',
+      value: stats.revenue,
+      growth: stats.orderGrowth,
+      color: '#eb3349',
+    },
+  ];
 
   return (
     <div className={s.root}>
@@ -89,7 +285,34 @@ const Dashboard = () => {
         <BreadcrumbItem>YOU ARE HERE</BreadcrumbItem>
         <BreadcrumbItem active>Dashboard</BreadcrumbItem>
       </Breadcrumb>
-      <h1 className="mb-lg">Dashboard</h1>
+      <div className={s.pageHeader}>
+        <h1 className="mb-lg mb-0">Dashboard</h1>
+        <TimeframeSelector value={timeframe} onChange={handleTimeframeChange} />
+      </div>
+
+      <Row className="mb-lg">
+        {statCards.map((card, index) => (
+          <Col key={index} xs={12} sm={6} lg={3}>
+            <StatCard {...card} />
+          </Col>
+        ))}
+      </Row>
+
+      <Widget
+        title={
+          <div className={s.chartTitle}>
+            <h5 className="mt-0 mb-0">
+              <Activity className="me-2 opacity-75" />
+              数据趋势
+            </h5>
+            <span className={s.chartSubtitle}>基于当前选择的时间段</span>
+          </div>
+        }
+        className="mb-lg"
+      >
+        <MainChart data={chartData} hasData={hasData} />
+      </Widget>
+
       <Row>
         <Col md={6} sm={12}>
           <Widget

--- a/src/pages/dashboard/Dashboard.module.scss
+++ b/src/pages/dashboard/Dashboard.module.scss
@@ -9,9 +9,181 @@
 
  @use '../../styles/app' as *;
 
- .root {
-   // styles here
- }
+.root {
+  // styles here
+}
+
+.pageHeader {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.timeframeGroup {
+  border-radius: 0.375rem;
+  box-shadow: 0 1px 3px rgba($gray-900, 0.08);
+
+  :global(.btn) {
+    border-color: rgba($gray-400, 0.5);
+    font-size: 0.875rem;
+    font-weight: $font-weight-semi-bold;
+    padding: 0.5rem 1rem;
+    transition: all 0.15s ease;
+
+    &:first-child {
+      border-top-left-radius: 0.375rem;
+      border-bottom-left-radius: 0.375rem;
+    }
+
+    &:last-child {
+      border-top-right-radius: 0.375rem;
+      border-bottom-right-radius: 0.375rem;
+    }
+
+    &.active,
+    &:not(.btn-outline-secondary):not(.btn-outline-primary) {
+      background-color: $brand-primary;
+      border-color: $brand-primary;
+      color: $white;
+    }
+
+    &.btn-outline-secondary {
+      background-color: $white;
+      color: $gray-600;
+
+      &:hover {
+        background-color: $gray-100;
+        border-color: $gray-400;
+        color: $gray-700;
+      }
+    }
+  }
+}
+
+.timeframeButton {
+  min-width: 70px;
+}
+
+.statCard {
+  border: 1px solid rgba($brand-primary, 0.08);
+  border-radius: 1rem;
+  box-shadow: 0 2px 8px rgba($gray-900, 0.04);
+  padding: 1.25rem;
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 4px 16px rgba($gray-900, 0.08);
+    transform: translateY(-2px);
+  }
+}
+
+.statCardInner {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+}
+
+.statCardIcon {
+  align-items: center;
+  border-radius: 0.75rem;
+  display: flex;
+  height: 3rem;
+  justify-content: center;
+  width: 3rem;
+}
+
+.statCardContent {
+  flex: 1;
+}
+
+.statCardTitle {
+  color: $gray-500;
+  font-size: 0.8125rem;
+  font-weight: $font-weight-normal;
+  letter-spacing: 0.02em;
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+}
+
+.statCardValue {
+  color: $gray-800;
+  font-size: 1.75rem;
+  font-weight: $font-weight-bold;
+  line-height: 1.2;
+  margin-bottom: 0.5rem;
+}
+
+.statCardGrowth {
+  align-items: center;
+  display: inline-flex;
+  font-size: 0.8125rem;
+  gap: 0.25rem;
+
+  &Positive {
+    color: $brand-success;
+  }
+
+  &Negative {
+    color: $brand-danger;
+  }
+}
+
+.statCardGrowthLabel {
+  color: $gray-400;
+  font-weight: $font-weight-normal;
+  margin-left: 0.125rem;
+}
+
+.chartTitle {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.chartSubtitle {
+  color: $gray-400;
+  font-size: 0.8125rem;
+}
+
+.emptyState {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  justify-content: center;
+  padding: 4rem 2rem;
+  text-align: center;
+}
+
+.emptyStateIcon {
+  align-items: center;
+  background-color: rgba($gray-300, 0.2);
+  border-radius: 50%;
+  color: $gray-400;
+  display: flex;
+  height: 5rem;
+  justify-content: center;
+  width: 5rem;
+}
+
+.emptyStateTitle {
+  color: $gray-700;
+  font-size: 1.125rem;
+  font-weight: $font-weight-semi-bold;
+  margin: 0;
+}
+
+.emptyStateMessage {
+  color: $gray-500;
+  font-size: 0.875rem;
+  margin: 0;
+  max-width: 20rem;
+}
  
  .usersTable {
    th,

--- a/src/pages/dashboard/mock.js
+++ b/src/pages/dashboard/mock.js
@@ -1,3 +1,95 @@
+const generateDateRange = (days) => {
+  const dates = [];
+  const today = new Date();
+  for (let i = days - 1; i >= 0; i--) {
+    const date = new Date(today);
+    date.setDate(date.getDate() - i);
+    dates.push(date);
+  }
+  return dates;
+};
+
+const formatDateLabel = (date, days) => {
+  if (days <= 7) {
+    return date.toLocaleDateString('zh-CN', { month: 'short', day: 'numeric' });
+  } else if (days <= 30) {
+    return date.toLocaleDateString('zh-CN', { month: 'short', day: 'numeric' });
+  } else {
+    return date.toLocaleDateString('zh-CN', { month: 'short' });
+  }
+};
+
+const generateChartData = (days, hasData = true) => {
+  if (!hasData) return [];
+
+  const dates = generateDateRange(days);
+  const data = [];
+  let pv = Math.floor(Math.random() * 2000) + 1000;
+  let uv = Math.floor(Math.random() * 1500) + 500;
+
+  const sampleRate = days <= 7 ? 1 : days <= 30 ? 2 : 7;
+
+  for (let i = 0; i < dates.length; i++) {
+    if (i % sampleRate === 0) {
+      pv = Math.max(500, pv + Math.floor(Math.random() * 600) - 300);
+      uv = Math.max(300, uv + Math.floor(Math.random() * 400) - 200);
+      data.push({
+        name: formatDateLabel(dates[i], days),
+        pv,
+        uv,
+      });
+    }
+  }
+  return data;
+};
+
+const generateStats = (days, hasData = true) => {
+  if (!hasData) {
+    return {
+      totalUsers: 0,
+      activeUsers: 0,
+      newOrders: 0,
+      revenue: 0,
+      userGrowth: 0,
+      orderGrowth: 0,
+    };
+  }
+
+  const baseMultiplier = days / 7;
+  return {
+    totalUsers: Math.floor((1240 + Math.random() * 500) * baseMultiplier),
+    activeUsers: Math.floor((850 + Math.random() * 300) * baseMultiplier),
+    newOrders: Math.floor((320 + Math.random() * 200) * baseMultiplier),
+    revenue: Math.floor((15680 + Math.random() * 10000) * baseMultiplier),
+    userGrowth: Math.floor(5 + Math.random() * 15),
+    orderGrowth: Math.floor(-5 + Math.random() * 20),
+  };
+};
+
+export const getDashboardData = (timeframe) => {
+  const daysMap = {
+    '7d': 7,
+    '30d': 30,
+    '90d': 90,
+  };
+
+  const days = daysMap[timeframe] || 7;
+  
+  const hasData = Math.random() > 0.1;
+
+  return {
+    stats: generateStats(days, hasData),
+    chartData: generateChartData(days, hasData),
+    hasData,
+  };
+};
+
+export const timeframeOptions = [
+  { value: '7d', label: '7天' },
+  { value: '30d', label: '30天' },
+  { value: '90d', label: '90天' },
+];
+
 export const mock = [
   {
     id: 123325,
@@ -24,4 +116,4 @@ export const mock = [
     updatedAt: '2019-11-14',
     title: 'Light Blue Vue Node.js - update version 3.0.5'
   },
-]
+];


### PR DESCRIPTION
Add 7d / 30d / 90d timeframe switch on dashboard.
Sync stat cards and main chart when switching.
Persist selected timeframe after refresh.
Add empty state handling for no-data ranges.